### PR TITLE
Fixed java:TestMethodWithoutAssertion constraint

### DIFF
--- a/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
+++ b/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
@@ -617,10 +617,12 @@
             OPTIONAL MATCH
               path=shortestPath((testMethod)-[:INVOKES|VIRTUAL_INVOKES*]->(assert:Method:Assert))
             WITH
-              testClass, testMethod, path
+              testClass, testMethod, COLLECT(length(path)) as lengths
+            WITH
+              testClass, testMethod, REDUCE(minVal = lengths[0], n IN lengths | CASE WHEN n < minVal THEN n ELSE minVal END) AS shortestPathLength
             WHERE
-              path is null
-              or length(path) > $javaTestAssertMaxCallDepth
+              shortestPathLength is null
+              or shortestPathLength > $javaTestAssertMaxCallDepth
             RETURN
               distinct testClass AS TestClass, testMethod AS TestMethod
             ORDER BY

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -319,13 +319,15 @@ public class Junit4IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(10));
+        assertThat(rows.size(), equalTo(12));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit5.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageSupplier")), is(methodDescriptor(Assertions4Junit5.class, "assertWithMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "repeatedTestWithoutAssertion")),
             is(methodDescriptor(Assertions4Junit5.class, "parameterizedTestWithoutAssertion", String.class)),
             is(methodDescriptor(Assertions4Junit5.class, "testWithoutAssertion")), is(methodDescriptor(Assertions4Junit5.class, "testWithAssertion")),
             is(methodDescriptor(Assertions4Junit5.class, "testWithNestedAssertion")),
+            is(methodDescriptor(Assertions4Junit5.class, "testWithDeepNestedAssertion")),
+            is(methodDescriptor(Assertions4Junit5.class, "testWithDeepAndShallowAssertion")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn")),
             is(methodDescriptor(Assertions4Junit5.class, "assertInSuperClass"))));
         store.commitTransaction();
@@ -351,11 +353,11 @@ public class Junit4IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(6));
+        assertThat(rows.size(), equalTo(7));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit5.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageSupplier")), is(methodDescriptor(Assertions4Junit5.class, "assertWithMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "testWithAssertion")), is(methodDescriptor(Assertions4Junit5.class, "testWithNestedAssertion")),
-            is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn"))));
+            is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn")), is(methodDescriptor(Assertions4Junit5.class, "testWithDeepAndShallowAssertion"))));
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/JunitCommonIT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/JunitCommonIT.java
@@ -204,7 +204,7 @@ public class JunitCommonIT extends AbstractJunitIT {
                 .getValue())
             .map(MethodDescriptor.class::cast)
             .collect(toList());
-        assertThat(methods.size(), equalTo(4));
+        assertThat(methods.size(), equalTo(5));
 
         assertThat(methods, containsInAnyOrder(methodDescriptor(Assertions4Junit4.class, "testWithoutAssertion"),
             methodDescriptor(Assertions4Junit5.class, "repeatedTestWithoutAssertion"),

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/JunitCommonIT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/JunitCommonIT.java
@@ -209,6 +209,7 @@ public class JunitCommonIT extends AbstractJunitIT {
         assertThat(methods, containsInAnyOrder(methodDescriptor(Assertions4Junit4.class, "testWithoutAssertion"),
             methodDescriptor(Assertions4Junit5.class, "repeatedTestWithoutAssertion"),
             methodDescriptor(Assertions4Junit5.class, "parameterizedTestWithoutAssertion", String.class),
+            methodDescriptor(Assertions4Junit5.class, "testWithDeepNestedAssertion"),
             methodDescriptor(Assertions4Junit5.class, "testWithoutAssertion")));
 
         store.commitTransaction();

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
@@ -56,7 +56,7 @@ public class Assertions4Junit5 extends AbstractAssertions4Junit5 {
 
     @Test
     public void testWithDeepAndShallowAssertion() {
-        assertTrue(true);
+        assertTrue(true, "Condition must be true");
         deepNestedAssertion();
     }
 
@@ -87,7 +87,7 @@ public class Assertions4Junit5 extends AbstractAssertions4Junit5 {
     }
 
     private void deepNestedAssertion3() {
-        assertTrue(true);
+        assertTrue(true, "Condition must be true");
     }
 
     private void throwsException() throws IllegalArgumentException {

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
@@ -50,6 +50,17 @@ public class Assertions4Junit5 extends AbstractAssertions4Junit5 {
     }
 
     @Test
+    public void testWithDeepNestedAssertion() {
+        deepNestedAssertion();
+    }
+
+    @Test
+    public void testWithDeepAndShallowAssertion() {
+        assertTrue(true);
+        deepNestedAssertion();
+    }
+
+    @Test
     public void assertWithNonVoidReturn() {
         assertThrows(IllegalArgumentException.class, this::throwsException);
     }
@@ -61,6 +72,22 @@ public class Assertions4Junit5 extends AbstractAssertions4Junit5 {
 
     private void nestedAssertion() {
         fail("Failing");
+    }
+
+    private void deepNestedAssertion() {
+        deepNestedAssertion1();
+    }
+
+    private void deepNestedAssertion1() {
+        deepNestedAssertion2();
+    }
+
+    private void deepNestedAssertion2() {
+        deepNestedAssertion3();
+    }
+
+    private void deepNestedAssertion3() {
+        assertTrue(true);
     }
 
     private void throwsException() throws IllegalArgumentException {


### PR DESCRIPTION
Currently, the java:TestMethodWithoutAssertion fails on test methods, that, at _any_ point invoke an assertion method within a depth greater 3, even if there are assert calls higher up the chain.

This pull requests attempts to fix this.