### PR TITLE
721: java:TestMethodWithoutAssertion should allow expected exceptions provided by @Test annotation

### DIFF
--- a/plugin/common/src/test/java/com/buschmais/jqassistant/plugin/common/impl/report/JUnitReportPluginTest.java
+++ b/plugin/common/src/test/java/com/buschmais/jqassistant/plugin/common/impl/report/JUnitReportPluginTest.java
@@ -11,7 +11,7 @@ import com.buschmais.jqassistant.core.report.api.ReportException;
 import com.buschmais.jqassistant.core.report.api.model.Column;
 import com.buschmais.jqassistant.core.report.api.model.Result;
 import com.buschmais.jqassistant.core.rule.api.model.*;
-import com.buschmais.jqassistant.core.shared.xml.JAXBUnmarshaller;
+import com.buschmais.jqassistant.core.shared.xml.JAXBHelper;
 import com.buschmais.jqassistant.plugin.junit.impl.schema.Error;
 import com.buschmais.jqassistant.plugin.junit.impl.schema.Failure;
 import com.buschmais.jqassistant.plugin.junit.impl.schema.Testcase;
@@ -34,7 +34,7 @@ public class JUnitReportPluginTest extends AbstractReportPluginTest {
 
     private static final String EXPECTED_CONTENT = "c = foo\n" + "---\n" + "c = bar\n";
 
-    private JAXBUnmarshaller<Testsuite> unmarshaller = new JAXBUnmarshaller(Testsuite.class);
+    private JAXBHelper<Testsuite> unmarshaller = new JAXBHelper(Testsuite.class);
 
     private Group testGroup = Group.builder().id("test:Group").description("testGroup").build();
     private Concept concept = Concept.builder().id("test:Concept").description("testConcept").severity(Severity.MINOR).build();

--- a/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
+++ b/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
@@ -605,24 +605,88 @@
         ]]></cypher>
     </concept>
 
-    <constraint id="java:TestMethodWithoutAssertion">
+    <concept id="java:AssertAnnotation">
+        <description>
+            An assert annotation is used to define an expected testing result (e.g. @Test(expected = RuntimeException.class)
+            for a test method.
+        </description>
+        <cypher><![CDATA[
+            MATCH
+              (type:Java:Type)-[:DECLARES]->(method:Method)-[:ANNOTATED_BY]->(annotation:Annotation:Assert)-[:OF_TYPE]->(annotationType:Java:Type)
+            RETURN
+              type AS DeclaringType, method AS AnnotatedTestMethod, annotationType AS AnnotationType
+            ORDER BY
+              type.fqn, method.fqn, annotationType.fqn
+        ]]></cypher>
+    </concept>
+
+    <concept id="java:PerformsAssertion">
+        <description>Returns all test methods performing at least one assertion.</description>
+        <cypher><![CDATA[
+            MATCH
+              (type:Java:Type)-[:DECLARES]->(testMethod:Method)-[:PERFORMS_ASSERTION]->(assertion:Assert)
+            RETURN
+              type AS DeclaringType, testMethod AS TestMethod
+            ORDER BY
+              type.fqn, testMethod.signature
+        ]]></cypher>
+    </concept>
+
+    <concept id="java:TestMethodPerformsMethodAssertion">
+        <providesConcept refId="java:PerformsAssertion"/>
         <requiresConcept refId="java:VirtualInvokes"/>
         <requiresConcept refId="java:TestMethod"/>
         <requiresConcept refId="java:AssertMethod"/>
         <requiresParameter name="javaTestAssertMaxCallDepth" type="int" defaultValue="3" />
-        <description>All test methods must perform assertions (within a call hierarchy of max. 3 steps).</description>
+        <description>
+            A test method performs a method assertion, if it invokes an assert method within a call hierarchy of max. 3 steps.
+        </description>
         <cypher><![CDATA[
             MATCH
               (testClass:Java:Type)-[:DECLARES]->(testMethod:Test:Method)
             OPTIONAL MATCH
-              path=shortestPath((testMethod)-[:INVOKES|VIRTUAL_INVOKES*]->(assert:Method:Assert))
+              (testMethod)-[invokes:INVOKES|VIRTUAL_INVOKES*]->(assertMethod:Method:Assert), path=shortestPath((testMethod)-[:INVOKES|VIRTUAL_INVOKES*]->(assertMethod))
             WITH
-              testClass, testMethod, COLLECT(length(path)) as lengths
-            WITH
-              testClass, testMethod, REDUCE(minVal = lengths[0], n IN lengths | CASE WHEN n < minVal THEN n ELSE minVal END) AS shortestPathLength
+              testClass, testMethod, assertMethod, length(path) as callDepth
             WHERE
-              shortestPathLength is null
-              or shortestPathLength > $javaTestAssertMaxCallDepth
+              callDepth is not null
+              and callDepth <= $javaTestAssertMaxCallDepth
+            MERGE
+              (testMethod)-[:PERFORMS_ASSERTION]->(assertMethod)
+            RETURN
+              distinct testClass AS TestClass, testMethod AS TestMethod, assertMethod as AssertMethod
+            ORDER BY
+              testClass.fqn, testMethod.name, AssertMethod.name
+        ]]></cypher>
+    </concept>
+
+    <concept id="java:TestMethodPerformsAnnotationAssertion">
+        <providesConcept refId="java:PerformsAssertion"/>
+        <requiresConcept refId="java:TestMethod"/>
+        <requiresConcept refId="java:AssertAnnotation"/>
+        <description>
+            A test method performs an annotation assertion, if it is annotated with an assert annotation.
+        </description>
+        <cypher><![CDATA[
+            MATCH
+              (testClass:Java:Type)-[:DECLARES]->(testMethod:Test:Method)-[:ANNOTATED_BY]->(assertAnnotation:Annotation:Assert)-[:OF_TYPE]->(annotationType:Java:Type)
+            MERGE
+              (testMethod)-[:PERFORMS_ASSERTION]->(assertAnnotation)
+            RETURN
+              distinct testClass AS TestClass, testMethod as TestMethod, annotationType AS AssertAnnotationType
+            ORDER BY
+              testClass.fqn, testMethod.fqn
+        ]]></cypher>
+    </concept>
+
+    <constraint id="java:TestMethodWithoutAssertion">
+        <requiresConcept refId="java:PerformsAssertion"/>
+        <description>All test methods must perform at least one assertion.</description>
+        <cypher><![CDATA[
+            MATCH
+              (testClass:Java:Type)-[:DECLARES]->(testMethod:Test:Method)
+            WHERE NOT
+              (testMethod)-[:PERFORMS_ASSERTION]->(:Assert)
             RETURN
               distinct testClass AS TestClass, testMethod AS TestMethod
             ORDER BY

--- a/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
+++ b/plugin/java/src/main/resources/META-INF/jqassistant-rules/java.xml
@@ -620,20 +620,20 @@
         ]]></cypher>
     </concept>
 
-    <concept id="java:PerformsAssertion">
+    <concept id="java:MethodPerformsAssertion">
         <description>Returns all test methods performing at least one assertion.</description>
         <cypher><![CDATA[
             MATCH
-              (type:Java:Type)-[:DECLARES]->(testMethod:Method)-[:PERFORMS_ASSERTION]->(assertion:Assert)
+              (type:Java:Type)-[:DECLARES]->(method:Method)-[:PERFORMS_ASSERTION]->(assertion:Assert)
             RETURN
-              type AS DeclaringType, testMethod AS TestMethod
+              type AS DeclaringType, method AS Method
             ORDER BY
-              type.fqn, testMethod.signature
+              type.fqn, method.signature
         ]]></cypher>
     </concept>
 
     <concept id="java:TestMethodPerformsMethodAssertion">
-        <providesConcept refId="java:PerformsAssertion"/>
+        <providesConcept refId="java:MethodPerformsAssertion"/>
         <requiresConcept refId="java:VirtualInvokes"/>
         <requiresConcept refId="java:TestMethod"/>
         <requiresConcept refId="java:AssertMethod"/>
@@ -645,7 +645,7 @@
             MATCH
               (testClass:Java:Type)-[:DECLARES]->(testMethod:Test:Method)
             OPTIONAL MATCH
-              (testMethod)-[invokes:INVOKES|VIRTUAL_INVOKES*]->(assertMethod:Method:Assert), path=shortestPath((testMethod)-[:INVOKES|VIRTUAL_INVOKES*]->(assertMethod))
+              path=shortestPath((testMethod)-[:INVOKES|VIRTUAL_INVOKES*]->(assertMethod:Method:Assert))
             WITH
               testClass, testMethod, assertMethod, length(path) as callDepth
             WHERE
@@ -661,7 +661,7 @@
     </concept>
 
     <concept id="java:TestMethodPerformsAnnotationAssertion">
-        <providesConcept refId="java:PerformsAssertion"/>
+        <providesConcept refId="java:MethodPerformsAssertion"/>
         <requiresConcept refId="java:TestMethod"/>
         <requiresConcept refId="java:AssertAnnotation"/>
         <description>
@@ -680,7 +680,7 @@
     </concept>
 
     <constraint id="java:TestMethodWithoutAssertion">
-        <requiresConcept refId="java:PerformsAssertion"/>
+        <requiresConcept refId="java:MethodPerformsAssertion"/>
         <description>All test methods must perform at least one assertion.</description>
         <cypher><![CDATA[
             MATCH

--- a/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/test/rules/JavaTestIT.java
+++ b/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/test/rules/JavaTestIT.java
@@ -87,17 +87,17 @@ class JavaTestIT extends AbstractJavaPluginIT {
     }
 
     @Test
-    void javaPerformsAssertion() throws RuleException {
-        Result<Concept> result = applyConcept("java:PerformsAssertion");
+    void javaMethodPerformsAssertion() throws RuleException {
+        Result<Concept> result = applyConcept("java:MethodPerformsAssertion");
         assertThat(result.getStatus()).isEqualTo(SUCCESS);
         assertThat(result.getRows()).hasSize(2);
         Map<String, Column<?>> annotationAssertion = result.getRows().get(0).getColumns();
         Map<String, Column<?>> methodAssertion = result.getRows().get(1).getColumns();
         store.beginTransaction();
         assertThat(annotationAssertion.get("DeclaringType").getLabel()).isEqualTo("Test");
-        assertThat(annotationAssertion.get("TestMethod").getLabel()).isEqualTo("void annotatedTest()");
+        assertThat(annotationAssertion.get("Method").getLabel()).isEqualTo("void annotatedTest()");
         assertThat(methodAssertion.get("DeclaringType").getLabel()).isEqualTo("Test");
-        assertThat(methodAssertion.get("TestMethod").getLabel()).isEqualTo("void test()");
+        assertThat(methodAssertion.get("Method").getLabel()).isEqualTo("void test()");
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit-common.xml
+++ b/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit-common.xml
@@ -89,7 +89,7 @@
     <constraint id="junit:TestMethodWithoutAssertion">
         <requiresConcept refId="java:VirtualInvokes"/>
         <requiresConcept refId="java:TestMethod"/>
-        <requiresConcept refId="java:PerformsAssertion"/>
+        <requiresConcept refId="java:MethodPerformsAssertion"/>
         <description>All test methods must perform assertions (within a call hierarchy of max. 3 steps).</description>
         <deprecated>This constraint has been replaced by "java:TestMethodWithoutAssertion".</deprecated>
         <cypher><![CDATA[

--- a/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit-common.xml
+++ b/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit-common.xml
@@ -89,14 +89,14 @@
     <constraint id="junit:TestMethodWithoutAssertion">
         <requiresConcept refId="java:VirtualInvokes"/>
         <requiresConcept refId="java:TestMethod"/>
-        <requiresConcept refId="java:AssertMethod"/>
+        <requiresConcept refId="java:PerformsAssertion"/>
         <description>All test methods must perform assertions (within a call hierarchy of max. 3 steps).</description>
         <deprecated>This constraint has been replaced by "java:TestMethodWithoutAssertion".</deprecated>
         <cypher><![CDATA[
             MATCH
               (testType:Type)-[:DECLARES]->(testMethod:Test:Method)
             WHERE
-              NOT (testMethod)-[:INVOKES|VIRTUAL_INVOKES*..3]->(:Method:Assert)
+              NOT (testMethod)-[:PERFORMS_ASSERTION]->(:Assert)
             RETURN
               testType AS DeclaringType,
               testMethod AS Method

--- a/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit4.xml
+++ b/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit4.xml
@@ -149,6 +149,23 @@
             ]]></cypher>
     </concept>
 
+    <concept id="junit4:AssertAnnotation">
+        <providesConcept refId="java:AssertAnnotation"/>
+        <requiresConcept refId="java:TestMethod"/>
+        <description>Labels @Test-Annotations with the parameter "expected" as assert annotations.</description>
+        <cypher><![CDATA[
+            MATCH
+              (testType:Java:Type)-[:DECLARES]->(annotatedTestMethod:Test:Method)-[:ANNOTATED_BY]->(annotation:Annotation)-[:OF_TYPE]->(:Java:Type {fqn: "org.junit.Test"}),
+              (annotation)-[:HAS]->(expectation:Java:Value {name: 'expected'})
+            SET
+              annotation:Junit4:Assert
+            RETURN
+              testType AS DeclaringType, annotatedTestMethod AS AnnotatedTestMethod
+            ORDER BY
+              testType.fqn, annotatedTestMethod.name
+        ]]></cypher>
+    </concept>
+
     <concept id="junit4:SuiteClass">
         <description>Labels all classes annotated by "@org.junit.runners.Suite.SuiteClasses" with "Junit4" and "Suite" and creates a relation "CONTAINS_TESTCLASS" to all referenced classes.</description>
         <cypher><![CDATA[

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -6,11 +6,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.buschmais.jqassistant.core.report.api.model.Column;
 import com.buschmais.jqassistant.core.report.api.model.Result;
 import com.buschmais.jqassistant.core.report.api.model.Row;
+import com.buschmais.jqassistant.core.rule.api.model.Concept;
 import com.buschmais.jqassistant.core.rule.api.model.Constraint;
 import com.buschmais.jqassistant.core.rule.api.model.RuleException;
 import com.buschmais.jqassistant.core.shared.map.MapBuilder;
+import com.buschmais.jqassistant.plugin.java.api.model.AnnotationDescriptor;
 import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
 import com.buschmais.jqassistant.plugin.junit.test.set.junit4.Assertions4Junit4;
 import com.buschmais.jqassistant.plugin.junit.test.set.junit4.IgnoredTest;
@@ -173,6 +176,29 @@ public class Junit4IT extends AbstractJunitIT {
         List<MethodDescriptor> methods = query("match (m:Assert:Junit4:Method) return m").getColumn("m");
         assertThat(methods, containsInAnyOrder(methodDescriptor(Assert.class, "assertTrue", boolean.class),
             methodDescriptor(Assert.class, "assertTrue", String.class, boolean.class), methodDescriptor(Assert.class, "fail", String.class)));
+        store.commitTransaction();
+    }
+
+    /**
+     * Verifies the concept "junit4:AssertAnnotation".
+     *
+     * @throws IOException
+     *     If the test fails.
+     * @throws NoSuchMethodException
+     *     If the test fails.
+     */
+    @Test
+    public void assertAnnotation() throws Exception {
+        scanClasses(Assertions4Junit4.class);
+        Result<Concept> result = applyConcept("java:AssertAnnotation");
+        store.beginTransaction();
+        assertThat(result.getStatus(), equalTo(SUCCESS));
+        Map<String, Column<?>> assertAnnotation = result.getRows()
+            .get(0)
+            .getColumns();
+        assertThat(assertAnnotation.get("DeclaringType").getLabel(), endsWith("test.set.junit4.Assertions4Junit4"));
+        assertThat(assertAnnotation.get("AnnotatedTestMethod").getLabel(), equalTo("void testWithExpectedRuntimeException()"));
+        assertThat(assertAnnotation.get("AnnotationType").getLabel(), equalTo("org.junit.Test"));
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -13,7 +13,6 @@ import com.buschmais.jqassistant.core.rule.api.model.Concept;
 import com.buschmais.jqassistant.core.rule.api.model.Constraint;
 import com.buschmais.jqassistant.core.rule.api.model.RuleException;
 import com.buschmais.jqassistant.core.shared.map.MapBuilder;
-import com.buschmais.jqassistant.plugin.java.api.model.AnnotationDescriptor;
 import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
 import com.buschmais.jqassistant.plugin.junit.test.set.junit4.Assertions4Junit4;
 import com.buschmais.jqassistant.plugin.junit.test.set.junit4.IgnoredTest;

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit5IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit5IT.java
@@ -464,10 +464,11 @@ public class Junit5IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(5));
+        assertThat(rows.size(), equalTo(6));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit4.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit4.class, "assertWithMessage")), is(methodDescriptor(Assertions4Junit4.class, "testWithoutAssertion")),
-            is(methodDescriptor(Assertions4Junit4.class, "testWithAssertion")), is(methodDescriptor(Assertions4Junit4.class, "testWithNestedAssertion"))));
+            is(methodDescriptor(Assertions4Junit4.class, "testWithAssertion")), is(methodDescriptor(Assertions4Junit4.class, "testWithNestedAssertion")),
+            is(methodDescriptor(Assertions4Junit4.class, "testWithExpectedRuntimeException"))));
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/Assertions4Junit4.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/Assertions4Junit4.java
@@ -33,6 +33,9 @@ public class Assertions4Junit4 {
         nestedAssertion();
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testWithExpectedRuntimeException(){};
+
     private void nestedAssertion() {
         fail("Failing");
     }


### PR DESCRIPTION
Extended the constraint java:TestMethodWithoutAssertions to support expected exceptions provided by the JUnit `@Test` annotation.