### PR TITLE
#739 junit<4/5>:AssertionMustProvideMessage returned false positives for assert methods with a non-void return type.

### DIFF
--- a/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit4.xml
+++ b/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit4.xml
@@ -139,8 +139,8 @@
             WHERE
               assertType.fqn = 'org.junit.Assert'
               and (
-                assertMethod.signature =~ 'void assert.*'
-                or assertMethod.signature =~ 'void fail.*'
+                assertMethod.signature CONTAINS ' assert'
+                or assertMethod.signature CONTAINS ' fail'
               )
             SET
               assertMethod:Junit4:Assert
@@ -208,7 +208,7 @@
               (testType:Type)-[:DECLARES]->(testMethod:Test:Method),
               (testMethod)-[invocation:INVOKES*]->(assertMethod:Junit4:Assert:Method)
             WHERE NOT (
-                assertMethod.signature =~ 'void assert.*\\(java.lang.String,.*\\)'
+                assertMethod.signature =~ '.*assert.*\\(java.lang.String,.*\\)'
                 or assertMethod.signature = 'void fail(java.lang.String)'
             )
             RETURN

--- a/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit5.xml
+++ b/plugin/junit/src/main/resources/META-INF/jqassistant-rules/junit5.xml
@@ -451,8 +451,8 @@
               (testType:Type)-[:DECLARES]->(testMethod:Test:Method),
               (testMethod)-[invocation:INVOKES]->(assertMethod:Junit5:Assert:Method)
             WHERE NOT (
-              assertMethod.signature =~ 'void assert.*\\(.*java.lang.String\\)'
-              or assertMethod.signature =~ 'void assert.*\\(.*java.util.function.Supplier\\)'
+              assertMethod.signature =~ '.*assert.*\\(.*java.lang.String\\)'
+              or assertMethod.signature =~ '.*assert.*\\(.*java.util.function.Supplier\\)'
               or assertMethod.signature = 'java.lang.Object fail(java.lang.String)'
             )
             RETURN

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -21,6 +21,7 @@ import com.buschmais.jqassistant.plugin.junit.test.set.junit4.TestSuite;
 import com.buschmais.jqassistant.plugin.junit.test.set.junit5.Assertions4Junit5;
 
 import org.junit.Assert;
+import org.junit.function.ThrowingRunnable;
 import org.junit.jupiter.api.Test;
 
 import static com.buschmais.jqassistant.core.report.api.model.Result.Status.FAILURE;
@@ -173,8 +174,9 @@ public class Junit4IT extends AbstractJunitIT {
         assertThat(applyConcept("java:AssertMethod").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
         List<MethodDescriptor> methods = query("match (m:Assert:Junit4:Method) return m").getColumn("m");
-        assertThat(methods, containsInAnyOrder(methodDescriptor(Assert.class, "assertTrue", boolean.class),
-            methodDescriptor(Assert.class, "assertTrue", String.class, boolean.class), methodDescriptor(Assert.class, "fail", String.class)));
+        assertThat(methods, containsInAnyOrder(methodDescriptor(Assert.class, "assertThrows", String.class, Class.class, ThrowingRunnable.class),
+            methodDescriptor(Assert.class, "assertTrue", boolean.class), methodDescriptor(Assert.class, "assertTrue", String.class, boolean.class),
+            methodDescriptor(Assert.class, "fail", String.class)));
         store.commitTransaction();
     }
 
@@ -344,7 +346,7 @@ public class Junit4IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(12));
+        assertThat(rows.size(), equalTo(13));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit5.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageSupplier")), is(methodDescriptor(Assertions4Junit5.class, "assertWithMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "repeatedTestWithoutAssertion")),
@@ -354,7 +356,8 @@ public class Junit4IT extends AbstractJunitIT {
             is(methodDescriptor(Assertions4Junit5.class, "testWithDeepNestedAssertion")),
             is(methodDescriptor(Assertions4Junit5.class, "testWithDeepAndShallowAssertion")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn")),
-            is(methodDescriptor(Assertions4Junit5.class, "assertInSuperClass"))));
+            is(methodDescriptor(Assertions4Junit5.class, "assertInSuperClass")),
+            is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageButNonVoidReturnType"))));
         store.commitTransaction();
     }
 
@@ -378,11 +381,12 @@ public class Junit4IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(7));
+        assertThat(rows.size(), equalTo(8));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit5.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageSupplier")), is(methodDescriptor(Assertions4Junit5.class, "assertWithMessage")),
             is(methodDescriptor(Assertions4Junit5.class, "testWithAssertion")), is(methodDescriptor(Assertions4Junit5.class, "testWithNestedAssertion")),
-            is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn")), is(methodDescriptor(Assertions4Junit5.class, "testWithDeepAndShallowAssertion"))));
+            is(methodDescriptor(Assertions4Junit5.class, "assertWithNonVoidReturn")), is(methodDescriptor(Assertions4Junit5.class, "testWithDeepAndShallowAssertion")),
+            is(methodDescriptor(Assertions4Junit5.class, "assertWithMessageButNonVoidReturnType"))));
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit5IT.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit5IT.java
@@ -464,11 +464,12 @@ public class Junit5IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(6));
+        assertThat(rows.size(), equalTo(7));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit4.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit4.class, "assertWithMessage")), is(methodDescriptor(Assertions4Junit4.class, "testWithoutAssertion")),
             is(methodDescriptor(Assertions4Junit4.class, "testWithAssertion")), is(methodDescriptor(Assertions4Junit4.class, "testWithNestedAssertion")),
-            is(methodDescriptor(Assertions4Junit4.class, "testWithExpectedRuntimeException"))));
+            is(methodDescriptor(Assertions4Junit4.class, "testWithExpectedRuntimeException")),
+            is(methodDescriptor(Assertions4Junit4.class, "assertWithMessageButNonVoidReturnType"))));
         store.commitTransaction();
     }
 
@@ -492,10 +493,11 @@ public class Junit5IT extends AbstractJunitIT {
                 .get("TestMethod")
                 .getValue())
             .collect(Collectors.toList());
-        assertThat(rows.size(), equalTo(4));
+        assertThat(rows.size(), equalTo(5));
         assertThat(rows, containsInAnyOrder(is(methodDescriptor(Assertions4Junit4.class, "assertWithoutMessage")),
             is(methodDescriptor(Assertions4Junit4.class, "assertWithMessage")), is(methodDescriptor(Assertions4Junit4.class, "testWithAssertion")),
-            is(methodDescriptor(Assertions4Junit4.class, "testWithNestedAssertion"))));
+            is(methodDescriptor(Assertions4Junit4.class, "testWithNestedAssertion")),
+            is(methodDescriptor(Assertions4Junit4.class, "assertWithMessageButNonVoidReturnType"))));
         store.commitTransaction();
     }
 

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/Assertions4Junit4.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/Assertions4Junit4.java
@@ -3,6 +3,7 @@ package com.buschmais.jqassistant.plugin.junit.test.set.junit4;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -12,6 +13,11 @@ public class Assertions4Junit4 {
     @Test
     public void assertWithoutMessage() {
         assertTrue(true);
+    }
+
+    @Test
+    public void assertWithMessageButNonVoidReturnType() {
+        assertThrows("Condition must be true", NullPointerException.class, null);
     }
 
     @Test

--- a/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
+++ b/plugin/junit/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit5/Assertions4Junit5.java
@@ -17,6 +17,11 @@ public class Assertions4Junit5 extends AbstractAssertions4Junit5 {
     }
 
     @Test
+    public void assertWithMessageButNonVoidReturnType() {
+        assertThrows(NullPointerException.class, null, "Condition must be true");
+    }
+
+    @Test
     public void assertWithMessageSupplier() {
         assertTrue(() -> true, () -> "S");
     }


### PR DESCRIPTION
closes #739 