### PR TITLE
Added a maven skip parameter to all Mojos

### DIFF
--- a/maven/src/main/java/com/buschmais/jqassistant/scm/maven/AbstractMojo.java
+++ b/maven/src/main/java/com/buschmais/jqassistant/scm/maven/AbstractMojo.java
@@ -68,7 +68,7 @@ public abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo 
     @Parameter
     private Properties properties;
 
-    @Parameter(property = "skip", defaultValue = "false")
+    @Parameter(property = "jqassistant.skip", defaultValue = "false")
     private boolean skip;
 
     /**

--- a/maven/src/main/java/com/buschmais/jqassistant/scm/maven/AbstractMojo.java
+++ b/maven/src/main/java/com/buschmais/jqassistant/scm/maven/AbstractMojo.java
@@ -68,6 +68,9 @@ public abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo 
     @Parameter
     private Properties properties;
 
+    @Parameter(property = "skip", defaultValue = "false")
+    private boolean skip;
+
     /**
      * The Maven Session.
      */
@@ -117,6 +120,10 @@ public abstract class AbstractMojo extends org.apache.maven.plugin.AbstractMojo 
         }
         // Synchronize on this class as multiple instances of the plugin may exist in parallel builds
         synchronized (AbstractMojo.class) {
+            if(skip) {
+                getLog().info("Skipping execution.");
+                return;
+            }
             MavenConfiguration configuration = getConfiguration();
             if (configuration.skip()) {
                 getLog().info("Skipping execution.");


### PR DESCRIPTION
This is an update to the maven plugin.
It adds an skip parameter to all mojos.
The processing of the yaml configuration for my use case takes 10 seconds. This too long for just to skip the processing.
 